### PR TITLE
Fix a copy-paste error on MySQL get_username docs

### DIFF
--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -448,7 +448,7 @@ impl MySqlConnectOptions {
         self.socket.as_ref()
     }
 
-    /// Get the server's port.
+    /// Get the current username.
     ///
     /// # Example
     ///


### PR DESCRIPTION
I suspect this is a copy-paste error, it's meant to say username, not port.

### Does your PR solve an issue?

Haven't checked, but I expect if anyone noticed, they'd just fix it rather than open an issue.

### Is this a breaking change?

No, documentation only.
